### PR TITLE
🌐 Enhanced City Images & Random City Timezone Fix

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -45,7 +45,16 @@
       "Bash(flutter analyze:*)",
       "Bash(sed:*)",
       "Bash(flutter test:*)",
-      "Bash(dart:*)"
+      "Bash(dart:*)",
+      "Bash(do cp \"C:\\flutter\\sky_mesh\\assets\\new_images\\timezones\\utc_minus_5\\bogota_$weather_00001_.webp\" \"C:\\flutter\\sky_mesh\\assets\\location_images\\regions\\south_america\\bogota_$weather.webp\")",
+      "Bash(do cp \"C:\\flutter\\sky_mesh\\assets\\new_images\\timezones\\utc_minus_5\\montreal_$weather_00001_.webp\" \"C:\\flutter\\sky_mesh\\assets\\location_images\\regions\\north_america\\montreal_$weather.webp\")",
+      "Bash(do cp \"C:\\flutter\\sky_mesh\\assets\\new_images\\timezones\\utc_plus_1\\madrid_$weather_00001_.webp\" \"C:\\flutter\\sky_mesh\\assets\\location_images\\regions\\europe\\madrid_$weather.webp\")",
+      "Bash(do cp \"C:\\flutter\\sky_mesh\\assets\\new_images\\timezones\\utc_plus_1\\milan_$weather_00001_.webp\" \"C:\\flutter\\sky_mesh\\assets\\location_images\\regions\\europe\\milan_$weather.webp\")",
+      "Bash(do cp \"C:\\flutter\\sky_mesh\\assets\\new_images\\timezones\\utc_plus_2\\cape_town_$weather_00001_.webp\" \"C:\\flutter\\sky_mesh\\assets\\location_images\\regions\\africa\\cape_town_$weather.webp\")",
+      "Bash(do cp \"C:\\flutter\\sky_mesh\\assets\\new_images\\timezones\\utc_plus_3\\doha_$weather_00001_.webp\" \"C:\\flutter\\sky_mesh\\assets\\location_images\\regions\\middle_east\\doha_$weather.webp\")",
+      "Bash(do cp \"C:\\flutter\\sky_mesh\\assets\\new_images\\timezones\\utc_plus_5_30\\delhi_$weather_00001_.webp\" \"C:\\flutter\\sky_mesh\\assets\\location_images\\regions\\asia\\delhi_$weather.webp\")",
+      "Bash(do cp \"C:\\flutter\\sky_mesh\\assets\\new_images\\timezones\\utc_plus_9\\osaka_$weather_00001_.webp\" \"C:\\flutter\\sky_mesh\\assets\\location_images\\regions\\asia\\osaka_$weather.webp\")",
+      "Bash(do cp \"C:\\flutter\\sky_mesh\\assets\\new_images\\timezones\\utc_plus_9\\tokyo_$weather_00002_.webp\" \"C:\\flutter\\sky_mesh\\assets\\location_images\\regions\\asia\\tokyo_$weather.webp\")"
     ],
     "deny": [],
     "ask": [],

--- a/lib/core/models/hourly_weather_data.dart
+++ b/lib/core/models/hourly_weather_data.dart
@@ -20,7 +20,7 @@ class HourlyWeatherForecast {
 
   factory HourlyWeatherForecast.fromJson(Map<String, dynamic> json) {
     return HourlyWeatherForecast(
-      dateTime: DateTime.fromMillisecondsSinceEpoch(json['dt'] * 1000),
+      dateTime: DateTime.fromMillisecondsSinceEpoch(json['dt'] * 1000, isUtc: true),
       temperature: json['main']['temp'].toDouble(),
       description: json['weather'][0]['description'],
       iconCode: json['weather'][0]['icon'],
@@ -31,7 +31,10 @@ class HourlyWeatherForecast {
   }
 
   String get temperatureString => '${temperature.round()}°';
-  String get hour => '${dateTime.hour.toString().padLeft(2, '0')}:${dateTime.minute.toString().padLeft(2, '0')}';
+  String get hour {
+    final localTime = dateTime.toLocal();
+    return '${localTime.hour.toString().padLeft(2, '0')}:${localTime.minute.toString().padLeft(2, '0')}';
+  }
   
   String get capitalizedDescription {
     return description.split(' ').map((word) => 

--- a/lib/core/models/weekly_weather_data.dart
+++ b/lib/core/models/weekly_weather_data.dart
@@ -24,11 +24,15 @@ class DailyWeatherForecast {
   String get minTemperatureString => '${minTemperature.round()}°';
   
   String get dayOfWeek {
+    final localDate = date.toLocal();
     const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
-    return weekdays[date.weekday % 7];
+    return weekdays[localDate.weekday % 7];
   }
   
-  String get dateString => '${date.month}/${date.day}';
+  String get dateString {
+    final localDate = date.toLocal();
+    return '${localDate.month}/${localDate.day}';
+  }
   
   String get capitalizedDescription {
     return description.split(' ').map((word) => 
@@ -38,7 +42,8 @@ class DailyWeatherForecast {
   
   bool get isToday {
     final now = DateTime.now();
-    return date.year == now.year && date.month == now.month && date.day == now.day;
+    final localDate = date.toLocal();
+    return localDate.year == now.year && localDate.month == now.month && localDate.day == now.day;
   }
 }
 
@@ -61,7 +66,7 @@ class WeeklyWeatherData {
     final Map<String, List<dynamic>> dailyData = {};
     
     for (var item in list) {
-      final dt = DateTime.fromMillisecondsSinceEpoch(item['dt'] * 1000);
+      final dt = DateTime.fromMillisecondsSinceEpoch(item['dt'] * 1000, isUtc: true);
       final dateKey = '${dt.year}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')}';
       
       if (!dailyData.containsKey(dateKey)) {
@@ -103,7 +108,7 @@ class WeeklyWeatherData {
       iconCode = noonData['weather'][0]['icon'];
       
       dailyForecasts.add(DailyWeatherForecast(
-        date: DateTime.fromMillisecondsSinceEpoch(dayData.first['dt'] * 1000),
+        date: DateTime.fromMillisecondsSinceEpoch(dayData.first['dt'] * 1000, isUtc: true),
         maxTemperature: maxTemp,
         minTemperature: minTemp,
         description: description,

--- a/lib/data/services/openweather_api_service.dart
+++ b/lib/data/services/openweather_api_service.dart
@@ -193,6 +193,7 @@ class OpenWeatherApiService implements
         longitude: weather.longitude,
         sunrise: weather.sunrise,
         sunset: weather.sunset,
+        timezone: weather.timezone, // 타임존 정보 추가
       );
       
     } catch (e) {
@@ -484,8 +485,10 @@ class RandomCityProvider {
     {'latitude': 10.8231, 'longitude': 106.6297, 'name': 'Ho Chi Minh City', 'country': 'VN'},
     {'latitude': 12.9716, 'longitude': 77.5946, 'name': 'Bangalore', 'country': 'IN'},
     {'latitude': 19.0760, 'longitude': 72.8777, 'name': 'Mumbai', 'country': 'IN'},
+    {'latitude': 28.7041, 'longitude': 77.1025, 'name': 'Delhi', 'country': 'IN'},
     {'latitude': 31.2304, 'longitude': 121.4737, 'name': 'Shanghai', 'country': 'CN'},
     {'latitude': 25.0330, 'longitude': 121.5654, 'name': 'Taipei', 'country': 'TW'},
+    {'latitude': 34.6937, 'longitude': 135.5023, 'name': 'Osaka', 'country': 'JP'},
     
     // 새로 추가된 아시아 도시들
     {'latitude': 43.0642, 'longitude': 141.3469, 'name': 'Sapporo', 'country': 'JP'},
@@ -498,6 +501,7 @@ class RandomCityProvider {
     {'latitude': 35.6892, 'longitude': 51.3890, 'name': 'Tehran', 'country': 'IR'},
     {'latitude': 24.7136, 'longitude': 46.6753, 'name': 'Riyadh', 'country': 'SA'},
     {'latitude': 32.0853, 'longitude': 34.7818, 'name': 'Tel Aviv', 'country': 'IL'},
+    {'latitude': 25.2854, 'longitude': 51.5310, 'name': 'Doha', 'country': 'QA'},
     {'latitude': 30.3285, 'longitude': 35.4444, 'name': 'Petra', 'country': 'JO'},
     {'latitude': 48.8566, 'longitude': 2.3522, 'name': 'Paris', 'country': 'FR'},
     {'latitude': 51.5074, 'longitude': -0.1278, 'name': 'London', 'country': 'GB'},
@@ -505,6 +509,8 @@ class RandomCityProvider {
     {'latitude': 41.9028, 'longitude': 12.4964, 'name': 'Rome', 'country': 'IT'},
     {'latitude': 52.3676, 'longitude': 4.9041, 'name': 'Amsterdam', 'country': 'NL'},
     {'latitude': 41.3851, 'longitude': 2.1734, 'name': 'Barcelona', 'country': 'ES'},
+    {'latitude': 40.4168, 'longitude': -3.7038, 'name': 'Madrid', 'country': 'ES'},
+    {'latitude': 45.4642, 'longitude': 9.1900, 'name': 'Milan', 'country': 'IT'},
     {'latitude': 50.0755, 'longitude': 14.4378, 'name': 'Prague', 'country': 'CZ'},
     {'latitude': 59.3293, 'longitude': 18.0686, 'name': 'Stockholm', 'country': 'SE'},
     {'latitude': 48.2082, 'longitude': 16.3738, 'name': 'Vienna', 'country': 'AT'},
@@ -526,6 +532,7 @@ class RandomCityProvider {
     {'latitude': 38.9072, 'longitude': -77.0369, 'name': 'Washington DC', 'country': 'US'},
     {'latitude': 43.6532, 'longitude': -79.3832, 'name': 'Toronto', 'country': 'CA'},
     {'latitude': 49.2827, 'longitude': -123.1207, 'name': 'Vancouver', 'country': 'CA'},
+    {'latitude': 45.5017, 'longitude': -73.5673, 'name': 'Montreal', 'country': 'CA'},
     {'latitude': 19.4326, 'longitude': -99.1332, 'name': 'Mexico City', 'country': 'MX'},
     
     // 새로 추가된 북미 도시들
@@ -535,6 +542,7 @@ class RandomCityProvider {
     {'latitude': -22.9068, 'longitude': -43.1729, 'name': 'Rio de Janeiro', 'country': 'BR'},
     {'latitude': -33.4489, 'longitude': -70.6693, 'name': 'Santiago', 'country': 'CL'},
     {'latitude': -23.5505, 'longitude': -46.6333, 'name': 'São Paulo', 'country': 'BR'},
+    {'latitude': 4.7110, 'longitude': -74.0721, 'name': 'Bogotá', 'country': 'CO'},
     
     // 새로 추가된 남미 도시들
     {'latitude': -13.1631, 'longitude': -72.5450, 'name': 'Machu Picchu', 'country': 'PE'},
@@ -542,6 +550,7 @@ class RandomCityProvider {
     {'latitude': -26.2041, 'longitude': 28.0473, 'name': 'Johannesburg', 'country': 'ZA'},
     {'latitude': -1.2921, 'longitude': 36.8219, 'name': 'Nairobi', 'country': 'KE'},
     {'latitude': 33.5731, 'longitude': -7.5898, 'name': 'Casablanca', 'country': 'MA'},
+    {'latitude': -33.9249, 'longitude': 18.4241, 'name': 'Cape Town', 'country': 'ZA'},
     {'latitude': -33.8688, 'longitude': 151.2093, 'name': 'Sydney', 'country': 'AU'},
     
     // 새로 추가된 오세아니아 도시들
@@ -550,10 +559,45 @@ class RandomCityProvider {
     {'latitude': -45.0312, 'longitude': 168.6626, 'name': 'Queenstown', 'country': 'NZ'},
   ];
 
+  // 최근에 보여준 도시들을 저장하는 버퍼
+  static final Set<String> _recentlyShownCities = <String>{};
+  
   static Map<String, dynamic> getRandomCity() {
-    final randomIndex = Random().nextInt(_cities.length);
-    return _cities[randomIndex];
+    // 사용 가능한 도시들 (최근에 보여준 도시들 제외)
+    final availableCities = _cities.where((city) {
+      return !_recentlyShownCities.contains(city['name']);
+    }).toList();
+    
+    // 모든 도시가 보여졌다면 버퍼를 리셋
+    if (availableCities.isEmpty) {
+      _recentlyShownCities.clear();
+      // 버퍼 리셋 후 다시 사용 가능한 도시들을 가져옴
+      final allCities = List<Map<String, dynamic>>.from(_cities);
+      final randomIndex = Random().nextInt(allCities.length);
+      final selectedCity = allCities[randomIndex];
+      
+      // 선택된 도시를 버퍼에 추가
+      _recentlyShownCities.add(selectedCity['name']);
+      return selectedCity;
+    }
+    
+    // 사용 가능한 도시 중에서 랜덤 선택
+    final randomIndex = Random().nextInt(availableCities.length);
+    final selectedCity = availableCities[randomIndex];
+    
+    // 선택된 도시를 버퍼에 추가
+    _recentlyShownCities.add(selectedCity['name']);
+    
+    return selectedCity;
   }
 
   static List<Map<String, dynamic>> getAllCities() => List.unmodifiable(_cities);
+  
+  // 버퍼 상태 확인용 메서드 (디버깅/테스트용)
+  static Set<String> getRecentlyShownCities() => Set.unmodifiable(_recentlyShownCities);
+  
+  // 버퍼 수동 리셋 메서드 (필요시 사용)
+  static void resetRecentlyShownBuffer() {
+    _recentlyShownCities.clear();
+  }
 }

--- a/lib/services/location_image_service.dart
+++ b/lib/services/location_image_service.dart
@@ -4,18 +4,18 @@
 /// 468개의 로우폴리 스타일 이미지를 관리하며, 지능적인 매칭 알고리즘을 사용합니다.
 /// 
 /// ## 이미지 컴렉션 구성
-/// - **68개 주요 도시**: 전 세계 7개 대륙의 대표 도시들
+/// - **76개 주요 도시**: 전 세계 7개 대륙의 대표 도시들
 /// - **6가지 날씨 조건**: cloudy, foggy, rainy, snowy, sunny, sunset
 /// - **10개 지역 대체**: 도시가 없는 지역의 대체 이미지
-/// - **총 468개 이미지**: (68개 도시 × 6개 날씨) + (10개 지역 × 6개 날씨)
+/// - **총 516개 이미지**: (76개 도시 × 6개 날씨) + (10개 지역 × 6개 날씨)
 /// 
 /// ## 지원 지역
-/// - **아시아**: 서울, 도쿄, 베이징, 방콕, 싱가포르, 마닐라, 자카르타, 쿠알라룸푸르, 호치민, 방갈로르, 뮄바이, 상하이, 타이베이
-/// - **중동**: 두바이, 테헤란, 리야드, 텔아비브
-/// - **유럽**: 파리, 런던, 베를린, 로마, 암스테르담, 바르셀로나, 프라하, 스톡홀름, 비엔나, 취리히, 모스크바, 이스탄불
-/// - **북미**: 뉴욕, 로스앤젬레스, 샌프란시스코, 시애틀, 시카고, 보스턴, 마이애미, 워싱턴DC, 토론토, 밴쿠버, 멕시코시티
-/// - **남미**: 부에노스아이레스, 리우데자네이루, 산티아고, 상파울루
-/// - **아프리카**: 카이로, 요하네스버그, 나이로비, 카사블랑카, 라고스
+/// - **아시아**: 서울, 도쿄, 베이징, 방콕, 싱가포르, 마닐라, 자카르타, 쿠알라룸푸르, 호치민, 방갈로르, 뮄바이, 델리, 상하이, 타이베이, 오사카
+/// - **중동**: 두바이, 테헤란, 리야드, 텔아비브, 도하
+/// - **유럽**: 파리, 런던, 베를린, 로마, 암스테르담, 바르셀로나, 마드리드, 밀라노, 프라하, 스톡홀름, 비엔나, 취리히, 모스크바, 이스탄불
+/// - **북미**: 뉴욕, 로스앤젤레스, 샌프란시스코, 시애틀, 시카고, 보스턴, 마이애미, 워싱턴DC, 토론토, 밴쿠버, 몬트리올, 멕시코시티
+/// - **남미**: 부에노스아이레스, 리우데자네이루, 산티아고, 상파울루, 보고타
+/// - **아프리카**: 카이로, 요하네스버그, 나이로비, 카사블랑카, 케이프타운, 라고스
 /// - **오세아니아**: 시드니, 멜버른
 /// 
 /// ## 이미지 선택 우선순위
@@ -60,6 +60,7 @@ class LocationImageService {
     'seoul': ['seoul'],
     'tokyo': ['tokyo'], 
     'beijing': ['beijing'],
+    'beijing_municipality': ['beijing'],  // API에서 "Beijing Municipality"로 오는 경우
     'bangkok': ['bangkok'],
     'singapore': ['singapore'],
     'manila': ['manila'],
@@ -68,8 +69,15 @@ class LocationImageService {
     'ho_chi_minh': ['ho_chi_minh'],
     'bangalore': ['bangalore'],
     'mumbai': ['mumbai'],
+    'delhi': ['delhi'],
     'shanghai': ['shanghai'],
+    'shanghai_municipality': ['shanghai'],  // API에서 "Shanghai Municipality"로 오는 경우
+    'tianjin': ['beijing'],  // 톈진은 베이징과 같은 지역
+    'tianjin_municipality': ['beijing'],  // API에서 "Tianjin Municipality"로 오는 경우
+    'chongqing': ['beijing'],  // 충칭은 베이징과 같은 지역
+    'chongqing_municipality': ['beijing'],  // API에서 "Chongqing Municipality"로 오는 경우
     'taipei': ['taipei'],
+    'osaka': ['osaka'],
     'sapporo': ['sapporo'],
     'bali': ['bali'],
     'phuket': ['phuket'],
@@ -131,6 +139,7 @@ class LocationImageService {
     'tehran': ['tehran'],
     'riyadh': ['riyadh'],
     'tel_aviv': ['tel_aviv'],
+    'doha': ['doha'],
     'petra': ['petra'],
     
     // 유럽
@@ -140,6 +149,8 @@ class LocationImageService {
     'rome': ['rome'],
     'amsterdam': ['amsterdam'],
     'barcelona': ['barcelona'],
+    'madrid': ['madrid'],
+    'milan': ['milan'],
     'prague': ['prague'],
     'stockholm': ['stockholm'],
     'vienna': ['vienna'],
@@ -159,8 +170,10 @@ class LocationImageService {
     'boston': ['boston'],
     'miami': ['miami'],
     'washington_dc': ['washington_dc'],
+    'washington': ['washington_dc'],  // "Washington"만으로 오는 경우
     'toronto': ['toronto'],
     'vancouver': ['vancouver'],
+    'montreal': ['montreal'],
     'mexico_city': ['mexico_city'],
     'cancun': ['cancun'],
     'aspen': ['aspen'],
@@ -170,6 +183,7 @@ class LocationImageService {
     'rio_de_janeiro': ['rio_de_janeiro'],
     'santiago': ['santiago'],
     'sao_paulo': ['sao_paulo'],
+    'bogota': ['bogota'],
     'machu_picchu': ['machu_picchu'],
     
     // 아프리카
@@ -177,6 +191,7 @@ class LocationImageService {
     'johannesburg': ['johannesburg'],
     'nairobi': ['nairobi'],
     'casablanca': ['casablanca'],
+    'cape_town': ['cape_town'],
     'lagos': ['lagos'],
     
     // 오세아니아
@@ -201,8 +216,10 @@ class LocationImageService {
     'ho_chi_minh': [10.8231, 106.6297],
     'bangalore': [12.9716, 77.5946],
     'mumbai': [19.0760, 72.8777],
+    'delhi': [28.7041, 77.1025],
     'shanghai': [31.2304, 121.4737],
     'taipei': [25.0330, 121.5654],
+    'osaka': [34.6937, 135.5023],
     'sapporo': [43.0642, 141.3469],
     'bali': [-8.3405, 115.0920],
     'phuket': [7.8804, 98.3923],
@@ -214,6 +231,7 @@ class LocationImageService {
     'tehran': [35.6892, 51.3890],
     'riyadh': [24.7136, 46.6753],
     'tel_aviv': [32.0853, 34.7818],
+    'doha': [25.2854, 51.5310],
     'petra': [30.3285, 35.4444],
     
     // 유럽
@@ -223,6 +241,8 @@ class LocationImageService {
     'rome': [41.9028, 12.4964],
     'amsterdam': [52.3676, 4.9041],
     'barcelona': [41.3851, 2.1734],
+    'madrid': [40.4168, -3.7038],
+    'milan': [45.4642, 9.1900],
     'prague': [50.0755, 14.4378],
     'stockholm': [59.3293, 18.0686],
     'vienna': [48.2082, 16.3738],
@@ -244,6 +264,7 @@ class LocationImageService {
     'washington_dc': [38.9072, -77.0369],
     'toronto': [43.6532, -79.3832],
     'vancouver': [49.2827, -123.1207],
+    'montreal': [45.5017, -73.5673],
     'mexico_city': [19.4326, -99.1332],
     'cancun': [21.1619, -86.8515],
     'aspen': [39.1911, -106.8175],
@@ -253,6 +274,7 @@ class LocationImageService {
     'rio_de_janeiro': [-22.9068, -43.1729],
     'santiago': [-33.4489, -70.6693],
     'sao_paulo': [-23.5505, -46.6333],
+    'bogota': [4.7110, -74.0721],
     'machu_picchu': [-13.1631, -72.5450],
     
     // 아프리카
@@ -260,6 +282,7 @@ class LocationImageService {
     'johannesburg': [-26.2041, 28.0473],
     'nairobi': [-1.2921, 36.8219],
     'casablanca': [33.5731, -7.5898],
+    'cape_town': [-33.9249, 18.4241],
     'lagos': [6.5244, 3.3792],
     
     // 오세아니아
@@ -275,7 +298,7 @@ class LocationImageService {
     // 아시아
     'KR': ['seoul'], 
     'KP': ['seoul'],  // 북한
-    'JP': ['tokyo', 'sapporo'],
+    'JP': ['tokyo', 'sapporo', 'osaka'],
     'CN': ['beijing', 'shanghai'],
     'TH': ['bangkok', 'phuket'],
     'SG': ['singapore'],
@@ -283,13 +306,14 @@ class LocationImageService {
     'ID': ['jakarta', 'bali'],
     'MY': ['kuala_lumpur'],
     'VN': ['ho_chi_minh'],
-    'IN': ['bangalore', 'mumbai'],
+    'IN': ['bangalore', 'mumbai', 'delhi'],
     'TW': ['taipei'],
     'KH': ['angkor_wat'],  // 캄보디아
     'MV': ['maldives'],    // 몰디브
     
     // 중동
     'AE': ['dubai'],
+    'QA': ['doha'],
     'IR': ['tehran'],
     'SA': ['riyadh'],
     'IL': ['tel_aviv'],
@@ -299,9 +323,9 @@ class LocationImageService {
     'FR': ['paris'],
     'GB': ['london'],
     'DE': ['berlin'],
-    'IT': ['rome'],
+    'IT': ['rome', 'milan'],
     'NL': ['amsterdam'],
-    'ES': ['barcelona'],
+    'ES': ['barcelona', 'madrid'],
     'CZ': ['prague'],
     'SE': ['stockholm'],
     'AT': ['vienna'],
@@ -313,18 +337,19 @@ class LocationImageService {
     
     // 북미
     'US': ['san_francisco', 'los_angeles', 'seattle', 'new_york', 'chicago', 'boston', 'miami', 'washington_dc', 'aspen', 'hawaii'],
-    'CA': ['toronto', 'vancouver'],
+    'CA': ['toronto', 'vancouver', 'montreal'],
     'MX': ['mexico_city', 'cancun'],
     
     // 남미
     'AR': ['buenos_aires'],
     'BR': ['rio_de_janeiro', 'sao_paulo'],
     'CL': ['santiago'],
+    'CO': ['bogota'],  // 콜롬비아
     'PE': ['machu_picchu'],  // 페루
     
     // 아프리카
     'EG': ['cairo'],
-    'ZA': ['johannesburg'],
+    'ZA': ['johannesburg', 'cape_town'],
     'KE': ['nairobi'],
     'MA': ['casablanca'],
     'NG': ['lagos'],
@@ -366,7 +391,6 @@ class LocationImageService {
     'TL': 'southeast_asia_extended', // 동티모르
     
     // 중동 (지원 도시 없는 국가들)  
-    'QA': 'middle_east',     // 카타르
     'KW': 'middle_east',     // 쿠웨이트
     'BH': 'middle_east',     // 바레인
     'OM': 'middle_east',     // 오만
@@ -448,7 +472,6 @@ class LocationImageService {
     'PT': 'eastern_europe',  // 포르투갈
     
     // 남미 (지원 도시 없는 국가들)
-    'CO': 'northern_andes',  // 콜롬비아
     'EC': 'northern_andes',  // 에콰도르
     'VE': 'northern_andes',  // 베네수엘라
     'BO': 'northern_andes',  // 볼리비아
@@ -509,7 +532,7 @@ class LocationImageService {
   /// 
   /// ## 선택 우선순위
   /// ### 1단계: 정확한 도시명 매칭
-  /// - 도시명이 68개 지원 도시와 정확히 일치
+  /// - 도시명이 76개 지원 도시와 정확히 일치
   /// - 예: "Seoul" → seoul_sunny.webp
   /// 
   /// ### 2단계: 같은 국가 내 도시 매칭
@@ -522,7 +545,7 @@ class LocationImageService {
   /// - 예: 파키스탄 → northern_india_cloudy.webp
   /// 
   /// ### 4단계: 랜덤 대체
-  /// - 모든 매칭이 실패한 경우 68개 도시 중 랜덤 선택
+  /// - 모든 매칭이 실패한 경우 76개 도시 중 랜덤 선택
   /// 
   /// ## 특별 처리 지역
   /// - **중국**: 방남부(위도 26도 이남)와 내륡 지역 구분
@@ -554,7 +577,7 @@ class LocationImageService {
     Logger.weather('$weatherDescription → $weather');
     
     // 우선순위 1: 정확한 도시명 매치 (예: 'seoul' → seoul_cloudy.webp)
-    final cityKey = cityName.toLowerCase().replaceAll(' ', '');
+    final cityKey = cityName.toLowerCase().replaceAll(' ', '_');
     if (_cityImages.containsKey(cityKey)) {
       final cityImageNames = _cityImages[cityKey]!;
       final selectedCity = cityImageNames[Random().nextInt(cityImageNames.length)];
@@ -753,19 +776,19 @@ class LocationImageService {
 
   /// 도시가 속한 지역 폴더명 반환
   /// 
-  /// 68개 지원 도시를 7개 지역 폴더로 분류하여 해당 도시가 속한
+  /// 76개 지원 도시를 7개 지역 폴더로 분류하여 해당 도시가 속한
   /// 지역명을 반환합니다. 이는 이미지 파일 경로 생성에 사용됩니다.
   /// 
   /// @param cityName 도시명 (예: "seoul", "paris")
   /// @return String 지역 폴더명
   /// 
   /// ## 지역 분류
-  /// - **asia**: 아시아 13개 도시
-  /// - **middle_east**: 중동 4개 도시  
-  /// - **europe**: 유럽 12개 도시
-  /// - **north_america**: 북미 11개 도시
-  /// - **south_america**: 남미 4개 도시
-  /// - **africa**: 아프리카 5개 도시
+  /// - **asia**: 아시아 15개 도시
+  /// - **middle_east**: 중동 5개 도시  
+  /// - **europe**: 유럽 14개 도시
+  /// - **north_america**: 북미 12개 도시
+  /// - **south_america**: 남미 5개 도시
+  /// - **africa**: 아프리카 6개 도시
   /// - **oceania**: 오세아니아 2개 도시
   /// 
   /// ## 기본값
@@ -784,12 +807,14 @@ class LocationImageService {
       'ho_chi_minh': 'asia',
       'bangalore': 'asia',
       'mumbai': 'asia',
+      'delhi': 'asia',
       
       // 중동
       'dubai': 'middle_east',
       'tehran': 'middle_east',
       'riyadh': 'middle_east',
       'tel_aviv': 'middle_east',
+      'doha': 'middle_east',
       
       // 유럽
       'paris': 'europe',
@@ -798,6 +823,8 @@ class LocationImageService {
       'rome': 'europe',
       'amsterdam': 'europe',
       'barcelona': 'europe',
+      'madrid': 'europe',
+      'milan': 'europe',
       'prague': 'europe',
       'stockholm': 'europe',
       'vienna': 'europe',
@@ -816,6 +843,7 @@ class LocationImageService {
       'washington_dc': 'north_america',
       'toronto': 'north_america',
       'vancouver': 'north_america',
+      'montreal': 'north_america',
       'mexico_city': 'north_america',
       
       // 남미
@@ -823,16 +851,19 @@ class LocationImageService {
       'rio_de_janeiro': 'south_america',
       'santiago': 'south_america',
       'sao_paulo': 'south_america',
+      'bogota': 'south_america',
       
       // 아프리카
       'cairo': 'africa',
       'johannesburg': 'africa',
       'nairobi': 'africa',
       'casablanca': 'africa',
+      'cape_town': 'africa',
       'lagos': 'africa',
       'shanghai': 'asia',
       'taipei': 'asia',
       'sapporo': 'asia',
+      'osaka': 'asia',
       'bali': 'asia',
       'phuket': 'asia',
       'angkor_wat': 'asia',

--- a/lib/widgets/weather_display_widget.dart
+++ b/lib/widgets/weather_display_widget.dart
@@ -655,10 +655,10 @@ class _WeatherDisplayWidgetState extends State<WeatherDisplayWidget>
 
           // === 현재 시간 ===
 
-          /// HH:mm 형식의 현재 시간 표시
-          /// 사용자가 언제 데이터를 확인하는지 알 수 있도록
+          /// HH:mm 형식의 도시 로컬 시간 표시
+          /// 선택된 도시의 시간대에 맞는 현재 시간 표시
           Text(
-            _getCurrentTime(),
+            widget.weatherData?.cityLocalTime ?? _getCurrentTime(),
             style: TextStyle(
               color: Colors.white.withValues(alpha: 0.8), // 날씨 정보보다 덜 강조
               fontSize: 16, // 보조 정보에 적합한 크기

--- a/test/services/chinese_municipalities_test.dart
+++ b/test/services/chinese_municipalities_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sky_mesh/services/location_image_service.dart';
+
+void main() {
+  group('Chinese Municipalities Mapping Tests', () {
+    
+    test('should map Chinese municipalities to correct cities', () {
+      final testCases = [
+        {'input': 'Shanghai Municipality', 'expected': 'shanghai'},
+        {'input': 'Beijing Municipality', 'expected': 'beijing'},
+        {'input': 'Tianjin Municipality', 'expected': 'beijing'},
+        {'input': 'Chongqing Municipality', 'expected': 'beijing'},
+        {'input': 'Washington', 'expected': 'washington_dc'},
+      ];
+
+      for (final testCase in testCases) {
+        final input = testCase['input']!;
+        final expected = testCase['expected']!;
+        
+        final result = LocationImageService.selectBackgroundImage(
+          cityName: input,
+          countryCode: 'CN',
+          weatherDescription: 'clear sky',
+        );
+
+        expect(result, contains('${expected}_sunny.webp'), 
+               reason: '$input should map to $expected image');
+        expect(result, isNot(contains('china_inland')), 
+               reason: '$input should not use China inland fallback');
+        
+        print('✅ $input → ${expected}_sunny.webp');
+      }
+    });
+
+    test('should handle case variations for all municipalities', () {
+      final testCases = [
+        'shanghai municipality',
+        'SHANGHAI MUNICIPALITY', 
+        'Shanghai Municipality',
+        'beijing municipality',
+        'BEIJING MUNICIPALITY',
+        'Beijing Municipality'
+      ];
+
+      for (final cityName in testCases) {
+        final result = LocationImageService.selectBackgroundImage(
+          cityName: cityName,
+          countryCode: 'CN',
+          weatherDescription: 'overcast clouds',
+        );
+        
+        // Beijing 또는 Shanghai 이미지를 사용해야 하고, china_inland fallback은 사용하면 안됨
+        expect(
+          result.contains('beijing_cloudy.webp') || result.contains('shanghai_cloudy.webp'),
+          true,
+          reason: '$cityName should map to beijing or shanghai, not china_inland'
+        );
+        expect(result, isNot(contains('china_inland')), 
+               reason: '$cityName should not use China inland fallback');
+        
+        print('✅ $cityName → specific city image (not china_inland)');
+      }
+    });
+  });
+}

--- a/test/services/new_cities_test.dart
+++ b/test/services/new_cities_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sky_mesh/services/location_image_service.dart';
+
+void main() {
+  group('New Cities Tests', () {
+    test('Delhi should return correct image path', () {
+      final imagePath = LocationImageService.selectBackgroundImage(
+        cityName: 'Delhi',
+        countryCode: 'IN',
+        weatherDescription: 'clear sky',
+      );
+
+      expect(imagePath, contains('delhi_sunny'));
+      expect(imagePath, contains('asia'));
+    });
+
+    test('Osaka should return correct image path', () {
+      final imagePath = LocationImageService.selectBackgroundImage(
+        cityName: 'Osaka',
+        countryCode: 'JP',
+        weatherDescription: 'rain',
+      );
+
+      expect(imagePath, contains('osaka_rainy'));
+      expect(imagePath, contains('asia'));
+    });
+
+    test('Madrid should return correct image path', () {
+      final imagePath = LocationImageService.selectBackgroundImage(
+        cityName: 'Madrid',
+        countryCode: 'ES',
+        weatherDescription: 'broken clouds',
+      );
+
+      expect(imagePath, contains('madrid_cloudy'));
+      expect(imagePath, contains('europe'));
+    });
+
+    test('Milan should return correct image path', () {
+      final imagePath = LocationImageService.selectBackgroundImage(
+        cityName: 'Milan',
+        countryCode: 'IT',
+        weatherDescription: 'snow',
+      );
+
+      expect(imagePath, contains('milan_snowy'));
+      expect(imagePath, contains('europe'));
+    });
+
+    test('Montreal should return correct image path', () {
+      final imagePath = LocationImageService.selectBackgroundImage(
+        cityName: 'Montreal',
+        countryCode: 'CA',
+        weatherDescription: 'foggy',
+      );
+
+      expect(imagePath, contains('montreal_foggy'));
+      expect(imagePath, contains('north_america'));
+    });
+
+    test('Bogota should return correct image path', () {
+      final imagePath = LocationImageService.selectBackgroundImage(
+        cityName: 'Bogota',
+        countryCode: 'CO',
+        weatherDescription: 'thunderstorm',
+      );
+
+      expect(imagePath, contains('bogota_rainy'));
+      expect(imagePath, contains('south_america'));
+    });
+
+    test('Cape Town should return correct image path', () {
+      final imagePath = LocationImageService.selectBackgroundImage(
+        cityName: 'cape_town',
+        countryCode: 'ZA',
+        weatherDescription: 'mist',
+      );
+
+      expect(imagePath, contains('cape_town_foggy'));
+      expect(imagePath, contains('africa'));
+    });
+
+    test('Doha should return correct image path', () {
+      final imagePath = LocationImageService.selectBackgroundImage(
+        cityName: 'Doha',
+        countryCode: 'QA',
+        weatherDescription: 'clear sky',
+      );
+
+      expect(imagePath, contains('doha_sunny'));
+      expect(imagePath, contains('middle_east'));
+    });
+
+    test('All new cities should be in supported cities list', () {
+      final supportedCities = LocationImageService.getAllSupportedCities();
+      
+      expect(supportedCities, contains('delhi'));
+      expect(supportedCities, contains('osaka'));
+      expect(supportedCities, contains('madrid'));
+      expect(supportedCities, contains('milan'));
+      expect(supportedCities, contains('montreal'));
+      expect(supportedCities, contains('bogota'));
+      expect(supportedCities, contains('cape_town'));
+      expect(supportedCities, contains('doha'));
+    });
+
+    test('Country mappings should include new cities', () {
+      expect(LocationImageService.getCitiesForCountry('IN'), contains('delhi'));
+      expect(LocationImageService.getCitiesForCountry('JP'), contains('osaka'));
+      expect(LocationImageService.getCitiesForCountry('ES'), contains('madrid'));
+      expect(LocationImageService.getCitiesForCountry('IT'), contains('milan'));
+      expect(LocationImageService.getCitiesForCountry('CA'), contains('montreal'));
+      expect(LocationImageService.getCitiesForCountry('CO'), contains('bogota'));
+      expect(LocationImageService.getCitiesForCountry('ZA'), contains('cape_town'));
+      expect(LocationImageService.getCitiesForCountry('QA'), contains('doha'));
+    });
+  });
+}

--- a/test/services/random_buffer_test.dart
+++ b/test/services/random_buffer_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sky_mesh/data/services/openweather_api_service.dart';
+
+void main() {
+  group('RandomCityProvider Buffer Tests', () {
+    setUp(() {
+      // 각 테스트 전에 버퍼를 리셋
+      RandomCityProvider.resetRecentlyShownBuffer();
+    });
+
+    test('should return different cities without repetition until all shown', () {
+      final allCities = RandomCityProvider.getAllCities();
+      final totalCities = allCities.length;
+      final shownCities = <String>{};
+
+      print('총 도시 수: $totalCities');
+
+      // 모든 도시가 한 번씩 나올 때까지 테스트
+      for (int i = 0; i < totalCities; i++) {
+        final randomCity = RandomCityProvider.getRandomCity();
+        final cityName = randomCity['name'];
+        
+        // 이미 보여진 도시가 다시 선택되지 않았는지 확인
+        expect(shownCities.contains(cityName), false, 
+               reason: '도시 "$cityName"가 이미 보여졌는데 다시 선택됨 (${i + 1}번째 시도)');
+        
+        shownCities.add(cityName);
+        
+        print('${i + 1}번째: $cityName');
+        
+        // 버퍼에 올바르게 추가되었는지 확인
+        final recentCities = RandomCityProvider.getRecentlyShownCities();
+        expect(recentCities.contains(cityName), true);
+        expect(recentCities.length, i + 1);
+      }
+
+      // 모든 도시가 선택되었는지 확인
+      expect(shownCities.length, totalCities);
+    });
+
+    test('should reset buffer and allow repetition after all cities shown', () {
+      final allCities = RandomCityProvider.getAllCities();
+      final totalCities = allCities.length;
+
+      // 먼저 모든 도시를 한 번씩 선택
+      for (int i = 0; i < totalCities; i++) {
+        RandomCityProvider.getRandomCity();
+      }
+
+      // 모든 도시가 선택된 후 버퍼가 가득 찬 상태 확인
+      expect(RandomCityProvider.getRecentlyShownCities().length, totalCities);
+
+      // 한 번 더 선택하면 버퍼가 리셋되고 새로운 도시가 선택되어야 함
+      final nextCity = RandomCityProvider.getRandomCity();
+      
+      // 버퍼가 리셋되어 1개만 있어야 함
+      expect(RandomCityProvider.getRecentlyShownCities().length, 1);
+      expect(RandomCityProvider.getRecentlyShownCities().contains(nextCity['name']), true);
+      
+      print('버퍼 리셋 후 선택된 도시: ${nextCity['name']}');
+    });
+
+    test('should include all newly added cities', () {
+      final allCities = RandomCityProvider.getAllCities();
+      final cityNames = allCities.map((city) => city['name']).toSet();
+
+      // 새로 추가된 8개 도시들이 포함되어 있는지 확인
+      final newCities = [
+        'Delhi', 'Osaka', 'Doha', 'Madrid',
+        'Milan', 'Montreal', 'Bogotá', 'Cape Town'
+      ];
+
+      for (final cityName in newCities) {
+        expect(cityNames.contains(cityName), true, 
+               reason: '새로 추가된 도시 "$cityName"가 목록에 없음');
+      }
+
+      print('새로 추가된 도시들이 모두 포함되어 있음: ${newCities.length}개');
+    });
+
+    test('should maintain randomness while avoiding repetition', () {
+      RandomCityProvider.resetRecentlyShownBuffer();
+      
+      final selectedCities = <String>[];
+      const testIterations = 10;
+
+      // 10개의 도시를 선택하여 모두 다른지 확인
+      for (int i = 0; i < testIterations; i++) {
+        final city = RandomCityProvider.getRandomCity();
+        final cityName = city['name'];
+        
+        expect(selectedCities.contains(cityName), false,
+               reason: '도시 "$cityName"가 ${i + 1}번째에 중복 선택됨');
+        
+        selectedCities.add(cityName);
+      }
+
+      expect(selectedCities.length, testIterations);
+      print('10번 연속 다른 도시 선택 성공');
+    });
+
+    test('should handle buffer reset correctly when full', () {
+      final allCities = RandomCityProvider.getAllCities();
+      final totalCities = allCities.length;
+      
+      // 모든 도시를 선택
+      for (int i = 0; i < totalCities; i++) {
+        RandomCityProvider.getRandomCity();
+      }
+      
+      // 버퍼가 가득 찬 상태
+      expect(RandomCityProvider.getRecentlyShownCities().length, totalCities);
+      
+      // 다음 선택 시 버퍼 리셋
+      final cityAfterReset = RandomCityProvider.getRandomCity();
+      
+      // 버퍼가 리셋되어 1개만 있어야 함
+      final bufferAfterReset = RandomCityProvider.getRecentlyShownCities();
+      expect(bufferAfterReset.length, 1);
+      expect(bufferAfterReset.contains(cityAfterReset['name']), true);
+      
+      print('버퍼 리셋 검증 완료');
+    });
+  });
+}

--- a/test/services/shanghai_municipality_test.dart
+++ b/test/services/shanghai_municipality_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sky_mesh/services/location_image_service.dart';
+
+void main() {
+  group('Shanghai Municipality Mapping Tests', () {
+
+    test('should map "Shanghai Municipality" to shanghai images', () {
+      // 다양한 날씨 조건에 대해 테스트 (실제 OpenWeather API에서 오는 형태)
+      final testCases = [
+        {'weather': 'clear sky', 'expected': 'shanghai_sunny.webp'},
+        {'weather': 'overcast clouds', 'expected': 'shanghai_cloudy.webp'},
+        {'weather': 'light rain', 'expected': 'shanghai_rainy.webp'},
+        {'weather': 'mist', 'expected': 'shanghai_foggy.webp'},
+        {'weather': 'light snow', 'expected': 'shanghai_snowy.webp'},
+      ];
+
+      for (final testCase in testCases) {
+        final weather = testCase['weather']!;
+        final expected = testCase['expected']!;
+        
+        final result = LocationImageService.selectBackgroundImage(
+          cityName: 'Shanghai Municipality',
+          countryCode: 'CN',
+          weatherDescription: weather,
+        );
+
+        expect(result, contains(expected), 
+               reason: 'Shanghai Municipality with $weather should map to shanghai image');
+        expect(result, contains('assets/location_images/regions/asia/$expected'),
+               reason: 'Should return full path to shanghai image');
+        
+        print('✅ Shanghai Municipality + $weather → $result');
+      }
+    });
+
+    test('should not fall back to China inland for Shanghai Municipality', () {
+      final result = LocationImageService.selectBackgroundImage(
+        cityName: 'Shanghai Municipality',
+        countryCode: 'CN',
+        weatherDescription: 'clear sky',
+      );
+
+      // China inland fallback이 아닌 정확한 shanghai 이미지를 반환해야 함
+      expect(result, contains('shanghai_sunny.webp'));
+      expect(result, isNot(contains('china_inland')), 
+             reason: 'Should not use China inland fallback for Shanghai Municipality');
+      
+      print('✅ Shanghai Municipality는 China inland fallback을 사용하지 않음');
+    });
+
+    test('should handle both "shanghai" and "Shanghai Municipality" identically', () {
+      final weather = 'clear sky';
+      
+      final shanghaiResult = LocationImageService.selectBackgroundImage(
+        cityName: 'shanghai',
+        countryCode: 'CN',
+        weatherDescription: weather,
+      );
+      final municipalityResult = LocationImageService.selectBackgroundImage(
+        cityName: 'Shanghai Municipality',
+        countryCode: 'CN',
+        weatherDescription: weather,
+      );
+      
+      expect(shanghaiResult, equals(municipalityResult), 
+             reason: '"shanghai"와 "Shanghai Municipality"는 동일한 이미지를 반환해야 함');
+      
+      print('✅ "shanghai"와 "Shanghai Municipality" 동일 처리 확인');
+    });
+
+    test('should properly handle case sensitivity', () {
+      final testCases = [
+        'Shanghai Municipality',
+        'shanghai municipality',
+        'SHANGHAI MUNICIPALITY',
+        'Shanghai municipality',
+        'shanghai Municipality'
+      ];
+
+      for (final cityName in testCases) {
+        final result = LocationImageService.selectBackgroundImage(
+          cityName: cityName,
+          countryCode: 'CN',
+          weatherDescription: 'overcast clouds',
+        );
+        
+        expect(result, contains('shanghai_cloudy.webp'), 
+               reason: '$cityName should be case-insensitive and map to shanghai');
+        
+        print('✅ $cityName → shanghai_cloudy.webp');
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- ✨ Add 8 new city images (Bogotá, Montreal, Madrid, Milan, Cape Town, Doha, Delhi, Osaka)
- 🎲 Enhanced random city selection with buffer system to avoid immediate repetition  
- 🔧 Fix Shanghai Municipality mapping issue (was showing China inland fallback)
- 🌐 Implement city-specific timezone display for random cities
- 🐛 Fix missing timezone field in _enhanceWeatherData method

## Key Features
### New Cities Added
- **South America**: Bogotá 🇨🇴
- **North America**: Montreal 🇨🇦  
- **Europe**: Madrid 🇪🇸, Milan 🇮🇹
- **Africa**: Cape Town 🇿🇦
- **Middle East**: Doha 🇶🇦
- **Asia**: Delhi 🇮🇳, Osaka 🇯🇵

### Random City Enhancement
- Buffer system prevents showing same cities repeatedly
- Even distribution ensures all cities get shown
- Buffer resets when all cities have been displayed

### Timezone Functionality
- Random cities now display their local time (not device time)
- Fixed timezone data preservation in API enhancement process
- Proper UTC to local time conversion for all cities

### Bug Fixes
- ✅ Shanghai Municipality mapping (was showing generic China inland)
- ✅ Beijing Municipality mapping consistency
- ✅ Timezone display for random cities

## Test Coverage
- ✅ New city integration tests
- ✅ Shanghai Municipality specific tests  
- ✅ Random buffer system tests
- ✅ Chinese municipalities mapping tests

## Technical Changes
- Enhanced `LocationImageService` with new city mappings
- Improved `RandomCityProvider` with buffer-based selection
- Fixed `_enhanceWeatherData` to preserve timezone information
- Updated `WeatherDisplayWidget` to use city-specific local time

🤖 Generated with [Claude Code](https://claude.ai/code)